### PR TITLE
Unnecessary displayMessage at translate command

### DIFF
--- a/ubiquity/standard-feeds/general.js
+++ b/ubiquity/standard-feeds/general.js
@@ -292,7 +292,6 @@ function googleTranslate(html, langCodePair, callback, pblock) {
     },
     error: function onGoogleTranslateError(xhr) {
       var stat = xhr.status + " " + xhr.statusText;
-      displayMessage(stat, self);
       Utils.reportInfo(self.name + ": " + stat);
     },
   };


### PR DESCRIPTION
Hey everybody :)

This commit just remove a line that contains an unnecessary displayMessage() at translate command!

This is the screenshot with the displayMessage() problem!

http://i51.tinypic.com/i2nh53.png
